### PR TITLE
make debugging easier with `babel-plugin-transform-react-jsx-source`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="/dev-toolkit-logo.png" alt="universal-dev-toolkit-logo" height='42'><sub><strong>v5.3.2</strong></sub>
+  <img src="/dev-toolkit-logo.png" alt="universal-dev-toolkit-logo" height='42'><sub><strong>v5.3.3</strong></sub>
 </p>
 <p align="center">
   Jump-start your <code>react</code>-powered Web App.<br/>

--- a/babelrc.js
+++ b/babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
   plugins: [
     require.resolve('jsx-control-statements'),
     require.resolve('babel-plugin-transform-class-properties'),
+    require.resolve('babel-plugin-transform-react-jsx-source'),
   ],
 
   extensions: ['.jsx', '.js'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-toolkit",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Javascript development toolkit for power users [ ES6, React, node-sass ]",
   "main": "index.js",
   "scripts": {
@@ -53,6 +53,7 @@
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.10.2",
+    "babel-plugin-transform-react-jsx-source": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",


### PR DESCRIPTION
This adds a plugin which shows the line-number on react-warnings. Quite useful!
Thanks for [the tip](https://twitter.com/dan_abramov/status/779308833399332864) Dan Abramov!

before:
![image](https://cloud.githubusercontent.com/assets/3392110/18872408/3541f34e-84b2-11e6-9ebc-b2a453dc4e14.png)

after:
![image](https://cloud.githubusercontent.com/assets/3392110/18872388/207b9064-84b2-11e6-84f2-754e6f68e968.png)
