### PR TITLE
Add ability to use stubs for dynamic render and server render

### DIFF
--- a/packages/dev-toolkit/package.json
+++ b/packages/dev-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-toolkit",
-  "version": "5.4.1",
+  "version": "5.5",
   "description": "Development Toolkit for React Veterans",
   "main": "index.js",
   "scripts": {
@@ -70,7 +70,7 @@
     "cross-spawn": "^4.0.0",
     "css-loader": "^0.23.1",
     "css-modules-require-hook": "^4.0.1",
-    "dynamic-pages": "^0.1.9",
+    "dynamic-pages": "^0.2",
     "eazy-logger": "^3.0.2",
     "errorhandler": "^1.4.3",
     "eslint": "^3.4.0",

--- a/packages/dev-toolkit/src/build.js
+++ b/packages/dev-toolkit/src/build.js
@@ -13,6 +13,19 @@ rimraf(PATHS.buildFolder, (error) => {
     console.log(error);
   }
 
+  if (scriptOptions.dynamic) {
+    // Use similar setup as for a test-environment (but with NODE_ENV set to `production`)
+    // eslint-disable-next-line global-require
+    require('./utils/testHelpers/setupDOM');
+
+    debug('dynamicRender.js exists?', fileExists(PATHS.dynamicRender));
+    // The external render file needs to be imported before compilation, in case any stubs exist
+    DynamicPages.importDynamicRenderFile({ dynamicRenderFile: PATHS.dynamicRenderFile });
+
+    // eslint-disable-next-line global-require
+    require('./utils/testHelpers/setupClientApp');
+  }
+
   const compiler = webpack(config);
   compiler.run((err) => {
     if (err) {
@@ -20,18 +33,9 @@ rimraf(PATHS.buildFolder, (error) => {
     }
 
     if (scriptOptions.dynamic) {
-      debug('dynamicRender.js exists?', fileExists(PATHS.dynamicRender));
-
-      // Use similar setup as for a test-environment (but with NODE_ENV set to `production`)
-      // eslint-disable-next-line global-require
-      require('./utils/testHelpers/setupDOM');
-      // eslint-disable-next-line global-require
-      require('./utils/testHelpers/setupClientApp');
-
       // Take index.html file and create an html-file for each route
       DynamicPages.generatePages({
         publicPath: PATHS.publicPath,
-        dynamicRenderFile: PATHS.dynamicRenderFile,
         buildFolder: PATHS.buildFolder,
         manifestFile: PATHS.manifestFile,
         doneCallback: () => console.log('\n ⭐️  Your build with dynamic pages is ready ⭐️'),

--- a/packages/dev-toolkit/src/webpack/config.js
+++ b/packages/dev-toolkit/src/webpack/config.js
@@ -53,7 +53,7 @@ export default createConfig({
   postcss,
   eslint,
 
-  //  Manage directories for dependencies with `resolve` & `resolveLoader`
+  // Manage directories for dependencies with `resolve` & `resolveLoader`
   resolve,
   resolveLoader,
 

--- a/packages/dynamic-pages/package.json
+++ b/packages/dynamic-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-pages",
-  "version": "0.1.9",
+  "version": "0.2",
   "description": "Dynamic page-loading utilities for react-router",
   "main": "dist/dynamicPages.js",
   "scripts": {

--- a/packages/dynamic-pages/src/dynamicPages.js
+++ b/packages/dynamic-pages/src/dynamicPages.js
@@ -9,6 +9,7 @@ import GenerateFiles from './dynamicPages/generateFiles';
 //   - what about images that are not lazily loaded?
 //       Possible solution could be to use `images-require-hook` instead of filesHook
 //       see: https://github.com/ptshih/images-require-hook
+// # find a way to separate server-only packages inside `generateFiles` from being bundled on client
 
 export default new class DynamicPages {
   constructor() {
@@ -182,11 +183,13 @@ export default new class DynamicPages {
 
   // The Dynamic Page Generator
   // NOTE: Server-usage only
-  generatePages({ publicPath, dynamicRenderFile, buildFolder, manifestFile, doneCallback }) {
+  importDynamicRenderFile({ dynamicRenderFile }) {
+    GenerateFiles.setupDynamicRenderFile({ dynamicRenderFile });
+  }
+  generatePages({ publicPath, buildFolder, manifestFile, doneCallback }) {
     if (!this.isClient) {
       GenerateFiles.run({
         publicPath,
-        dynamicRenderFile,
         buildFolder,
         manifestFile,
         definedRoutes: this.definedRoutes,


### PR DESCRIPTION
Stubs like these are now possible with `dynamicRender.js` and in the server-portion of an app:

```js
// stub an empty fetch method
global.fetch = () => new Promise(() => {});

// stub matchMedia
global.window.matchMedia = () => ({
  matches: false,
  addListener: () => {},
  removeListener: () => {},
});
```