### PR TITLE
Add promise-hooks to dynamic-pages

### DIFF
--- a/packages/dev-toolkit/package.json
+++ b/packages/dev-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-toolkit",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "Development Toolkit for React Veterans",
   "main": "index.js",
   "scripts": {

--- a/packages/dev-toolkit/package.json
+++ b/packages/dev-toolkit/package.json
@@ -70,7 +70,7 @@
     "cross-spawn": "^4.0.0",
     "css-loader": "^0.23.1",
     "css-modules-require-hook": "^4.0.1",
-    "dynamic-pages": "^0.2.0",
+    "dynamic-pages": "^0.2.1",
     "eazy-logger": "^3.0.2",
     "errorhandler": "^1.4.3",
     "eslint": "^3.4.0",

--- a/packages/dynamic-pages/package.json
+++ b/packages/dynamic-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-pages",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Dynamic page-loading utilities for react-router",
   "main": "dist/dynamicPages.js",
   "scripts": {

--- a/packages/dynamic-pages/src/dynamicPages.js
+++ b/packages/dynamic-pages/src/dynamicPages.js
@@ -74,8 +74,8 @@ export default new class DynamicPages {
   }
 
   // Save the route and returns needed props to react-router
-  defineRoute({ renderPath, components }) {
-    this.definedRoutes.push({ renderPath, components });
+  defineRoute({ renderPath, components, dynamicData }) {
+    this.definedRoutes.push({ renderPath, components, dynamicData });
 
     // Make it work with react-router by returning necessary props
     // see: https://github.com/ReactTraining/react-router/blob/master/docs/guides/DynamicRouting.md

--- a/packages/dynamic-pages/src/dynamicPages.js
+++ b/packages/dynamic-pages/src/dynamicPages.js
@@ -188,7 +188,7 @@ export default new class DynamicPages {
   }
   generatePages({ publicPath, buildFolder, manifestFile, doneCallback }) {
     if (!this.isClient) {
-      GenerateFiles.run({
+      GenerateFiles.startRendering({
         publicPath,
         buildFolder,
         manifestFile,

--- a/packages/dynamic-pages/src/dynamicPages/generateFiles.js
+++ b/packages/dynamic-pages/src/dynamicPages/generateFiles.js
@@ -119,7 +119,7 @@ export default new class GenerateFiles {
     }
   }
 
-  generateFile({ renderPath, components, manifestData, data, callback }) {
+  generateFile({ renderPath, components, manifestData, indexData, callback }) {
     const routePath = path.resolve(this.buildFolder, renderPath.substring(1));
     const names = (() => {
       let componentNames = '';
@@ -130,34 +130,37 @@ export default new class GenerateFiles {
     })();
 
     // eslint-disable-next-line max-len, no-console
-    console.log(chalk.blue('>'), `Generating route ${chalk.magenta(renderPath)} with: ${names}`);
+    console.log(chalk.blue('>'), `2-Generating route ${chalk.magenta(renderPath)} with: ${names}`);
 
     mkdirp(routePath, (mkdirError) => {
+      console.log('created directory');
       if (mkdirError) {
         // eslint-disable-next-line no-console
         console.error(mkdirError);
       } else {
+        console.log('writing file');
         const { reactHtml, additionalData } = this.dynamicRender(renderPath);
+        console.log(chalk.blue('⇢'), ' writing file');
 
         if (reactHtml) {
           const htmlWithAssets = this.convertAssetPaths(manifestData, reactHtml);
           const componentPaths = this.extractComponentPaths({ manifestData, components });
           const completeHtml = this.injectMarkupIntoTemplate({
-            data,
+            indexData,
             htmlWithAssets,
             componentPaths,
             additionalData,
           });
-          console.log(chalk.blue('⇢'), ` writing file`);
+          console.log(chalk.blue('⇢⇢'), ' writing file');
 
           fs.writeFile(path.resolve(routePath, 'index.html'), completeHtml, (writeError) => {
             if (writeError) {
               throw writeError;
             }
-            console.log(chalk.blue('⇢'), ` written file`);
+            console.log(chalk.blue('⇢'), ' written file');
 
             if (this.afterRouteRender) {
-              console.log(chalk.blue('⇢'), ` afterRouteRender`);
+              console.log(chalk.blue('⇢'), ' afterRouteRender');
               this.afterRouteRender({ renderPath, components, manifestData, routePath }).then(
                 () => callback ? callback() : null
               );
@@ -222,12 +225,12 @@ export default new class GenerateFiles {
     return extractedPaths;
   }
 
-  injectMarkupIntoTemplate({ data, htmlWithAssets, componentPaths, additionalData }) {
+  injectMarkupIntoTemplate({ indexData, htmlWithAssets, componentPaths, additionalData }) {
     const dynamicComponents = componentPaths.map(dynamicComponentPath => (
       `<script src="${this.publicPath}${dynamicComponentPath}"></script>`
     )).join('\n\t\t');
 
-    let formattedData = data.replace(
+    let formattedData = indexData.replace(
       '<!-- [[[reactHtml]]] -->',
       htmlWithAssets
     ).replace(

--- a/packages/dynamic-pages/src/dynamicPages/generateFiles.js
+++ b/packages/dynamic-pages/src/dynamicPages/generateFiles.js
@@ -124,34 +124,41 @@ export default new class GenerateFiles {
 
   createPagesFromCompiledData({ manifestData, indexData }) {
     return new Promise((resolve) => {
-      const promises = this.definedRoutes.map(({ renderPath, components }) =>
-        this.createPage({ renderPath, components, manifestData, indexData }));
+      const promises = this.definedRoutes.map(({ renderPath, components, dynamicData }) =>
+        this.createPage({ renderPath, components, dynamicData, manifestData, indexData }));
 
       Promise.all(promises).then(resolve);
     });
   }
 
-  createPage({ renderPath, components, manifestData, indexData }) {
+  createPage({ renderPath, components, dynamicData, manifestData, indexData }) {
     return new Promise((resolve) => {
       const afterRouteRender = ({ routePath }) => {
         if (this.afterRouteRender) {
           console.log(chalk.blue('⇢'), ` afterRouteRender (${chalk.blue(renderPath)})`);
-          this.afterRouteRender({ renderPath, components, manifestData, indexData, routePath })
-            .then(resolve);
+          this.afterRouteRender({
+            renderPath,
+            components,
+            dynamicData,
+            manifestData,
+            indexData,
+            routePath
+          }).then(resolve);
         } else {
           resolve();
         }
       };
 
+      // Only render routes that have no parameters
       if (!this.hasPathParameters(renderPath)) {
         if (this.beforeRouteRender) {
           console.log(chalk.blue('⇥'), ` beforeRouteRender (${chalk.blue(renderPath)})`);
           this.beforeRouteRender({ renderPath, components, manifestData, indexData }).then(() =>
-            this.renderRoute({ renderPath, components, manifestData, indexData })
+            this.renderRoute({ renderPath, components, dynamicData, manifestData, indexData })
               .then(afterRouteRender)
           );
         } else {
-          this.renderRoute({ renderPath, components, manifestData, indexData })
+          this.renderRoute({ renderPath, components, dynamicData, manifestData, indexData })
             .then(afterRouteRender);
         }
       } else {

--- a/packages/dynamic-pages/src/dynamicPages/generateFiles.js
+++ b/packages/dynamic-pages/src/dynamicPages/generateFiles.js
@@ -79,7 +79,7 @@ export default new class GenerateFiles {
   }
 
   renderRoutes(){
-    if (this.onRouteRender || this.dynamicRender) {
+    if (this.dynamicRender || this.onRouteRender) {
       try {
         console.log('Generating', chalk.magenta('index.html'), 'for each route...');
 
@@ -202,17 +202,17 @@ export default new class GenerateFiles {
             }
           };
 
-          if (this.onRouteRender) {
-            console.log(
-              chalk.blue('⤳'), ` onRouteRender ${chalk.magenta(renderPath)} with: ${names}`);
-            // asynchronous, expects a promise
-            this.onRouteRender(renderPath, dynamicData).then(renderAndResolve);
-          } else {
+          if (this.dynamicRender) {
+            // synchronous rendering
             console.log(
               chalk.blue('>'), `Rendering route ${chalk.magenta(renderPath)} with: ${names}`);
-            // synchronous
             const { reactHtml, additionalData } = this.dynamicRender(renderPath, dynamicData);
             renderAndResolve({ reactHtml, additionalData });
+          } else if (this.onRouteRender) {
+            // asynchronous rendering, expects a promise
+            console.log(
+              chalk.blue('⤳'), ` onRouteRender ${chalk.magenta(renderPath)} with: ${names}`);
+            this.onRouteRender(renderPath, dynamicData).then(renderAndResolve);
           }
         }
       });

--- a/packages/dynamic-pages/src/dynamicPages/generateFiles.js
+++ b/packages/dynamic-pages/src/dynamicPages/generateFiles.js
@@ -159,7 +159,6 @@ export default new class GenerateFiles {
             dynamicData,
             manifestData,
             indexData,
-            routePath,
           }).then(() =>
             this.renderRoute({ renderPath, components, dynamicData, manifestData, indexData })
             .then(afterRouteRender)

--- a/packages/dynamic-pages/src/dynamicPages/generateFiles.js
+++ b/packages/dynamic-pages/src/dynamicPages/generateFiles.js
@@ -142,7 +142,7 @@ export default new class GenerateFiles {
             dynamicData,
             manifestData,
             indexData,
-            routePath
+            routePath,
           }).then(resolve);
         } else {
           resolve();
@@ -153,9 +153,16 @@ export default new class GenerateFiles {
       if (!this.hasPathParameters(renderPath)) {
         if (this.beforeRouteRender) {
           console.log(chalk.gray('⇥'), ` beforeRouteRender (${chalk.blue(renderPath)})`);
-          this.beforeRouteRender({ renderPath, components, manifestData, indexData }).then(() =>
+          this.beforeRouteRender({
+            renderPath,
+            components,
+            dynamicData,
+            manifestData,
+            indexData,
+            routePath,
+          }).then(() =>
             this.renderRoute({ renderPath, components, dynamicData, manifestData, indexData })
-              .then(afterRouteRender)
+            .then(afterRouteRender)
           );
         } else {
           this.renderRoute({ renderPath, components, dynamicData, manifestData, indexData })


### PR DESCRIPTION
Allow for a variety of hooks with promises when rendering dynamic pages.
Added the following hooks:
- `beforeRender`
- `afterRender`
- `beforeRouteRender`
- `afterRouteRender`
- `onRouteRender`

![dynamic-render](https://cloud.githubusercontent.com/assets/3392110/24655415/22ea2b9e-1936-11e7-936a-85d029a93b1d.gif)

Example of `src/server/dynamicRender.js`:
```js
// NOTE: This file is only run when building dynamic pages with `dev-toolkit --build --dynamic`

// make any stubs available for server-rendering
// Example Stub: global.fetch = () => new Promise(() => {});
import 'src/server/utils/serverStubs';

import { match, createMemoryHistory } from 'react-router';
import { generateReactHTML } from 'src/server/utils';
import serialize from 'serialize-javascript';

import store from '../client/redux/store';
import routes from '../client/routes';

// create initial state (only once) for all routes
const initialReduxState = store.getState();

export const beforeRender = ({ definedRoutes }) => new Promise((resolve) => {
  // do something before rendering all routes, such as:
  // fetchAndStoreCache({ definedRoutes, onFinish: resolve });
  resolve();
});

export const afterRender = ({ definedRoutes }) => new Promise((resolve) => {
  // do something after rendering all routes
  resolve();
});

export const beforeRouteRender = ({
  renderPath, components, dynamicData, manifestData, indexData,
}) => new Promise((resolve) => {
  // do something before rendering a single route
  resolve();
});

export const afterRouteRender = ({
  renderPath, components, dynamicData, manifestData, indexData, routePath,
}) => new Promise((resolve) => {
  // do something after rendering a single route
  resolve();
});

export const onRouteRender = ({
  renderPath, components, dynamicData, manifestData, indexData
}) => new Promise((resolve) => {
  // async render - return a promise when rendering a route

  const browserHistory = createMemoryHistory();
  let reactHtml = null;
  match({ routes, location }, (error, redirectLocation, renderProps) => {
    reactHtml = generateReactHTML({ store, routes, browserHistory, renderProps });
  });

  resolve({
    reactHtml,
    additionalData: {
      initialReduxState:
        `<script>window.__PRELOADED_STATE__ = ${serialize(initialReduxState)}</script>`,
    },
  });
});

export default (location) => {
  // sync render - render a route synchronously,
  // NOTE: This is the default and will take precedence over `onRouteRender` if both are declared

  const browserHistory = createMemoryHistory();
  let reactHtml = null;
  match({ routes, location }, (error, redirectLocation, renderProps) => {
    reactHtml = generateReactHTML({ store, routes, browserHistory, renderProps });
  });

  return {
    reactHtml,
    additionalData: {
      initialReduxState:
        `<script>window.__PRELOADED_STATE__ = ${serialize(initialReduxState)}</script>`,
    },
  };
};

```

edit: Snippet changed to show [latest version of `onRouteRender`](https://github.com/stoikerty/dev-toolkit/pull/41) options