### PR TITLE
make client envs explicit via toolkitSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,23 @@ dev-toolkit -v
 
 #### Define what modules are bundled into `vendor.js`
 ```js
-// in your package.json, add `toolkitSettings` section
+// in your package.json, add `vendor` in `toolkitSettings` section
 "toolkitSettings": {
   "vendor": [
     "react",
     "react-dom",
     "react-router"
+  ]
+},
+```
+
+#### Define what environment variables are available on client
+```js
+// in your package.json, add `sharedEnvs` in `toolkitSettings` section
+"toolkitSettings": {
+  "sharedEnvs": [
+    "NODE_ENV",
+    "API_DOMAIN"
   ]
 },
 ```

--- a/packages/dev-toolkit/README.md
+++ b/packages/dev-toolkit/README.md
@@ -87,12 +87,23 @@ dev-toolkit -v
 
 #### Define what modules are bundled into `vendor.js`
 ```js
-// in your package.json, add `toolkitSettings` section
+// in your package.json, add `vendor` in `toolkitSettings` section
 "toolkitSettings": {
   "vendor": [
     "react",
     "react-dom",
     "react-router"
+  ]
+},
+```
+
+#### Define what environment variables are available on client
+```js
+// in your package.json, add `sharedEnvs` in `toolkitSettings` section
+"toolkitSettings": {
+  "sharedEnvs": [
+    "NODE_ENV",
+    "API_DOMAIN"
   ]
 },
 ```

--- a/packages/dev-toolkit/package.json
+++ b/packages/dev-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-toolkit",
-  "version": "5.5.4",
+  "version": "5.6.0",
   "description": "Development Toolkit for React Veterans",
   "main": "index.js",
   "scripts": {

--- a/packages/dev-toolkit/src/_userSettings.js
+++ b/packages/dev-toolkit/src/_userSettings.js
@@ -25,6 +25,9 @@ export const rootForToolkit = path.resolve(__dirname, '../');
 debug('rootForToolkit', rootForToolkit);
 
 const pkg = requireOrNull(path.resolve(rootForRequire, 'package.json')) || {};
+export const sharedEnvs = pkg.toolkitSettings && pkg.toolkitSettings.sharedEnvs ?
+  pkg.toolkitSettings.sharedEnvs : ['NODE_ENV'];
+debug('sharedEnvs', sharedEnvs);
 export const vendor = pkg.toolkitSettings && pkg.toolkitSettings.vendor ?
   pkg.toolkitSettings.vendor : [];
 debug('vendor', vendor);

--- a/packages/dev-toolkit/src/webpack/config/plugins.js
+++ b/packages/dev-toolkit/src/webpack/config/plugins.js
@@ -11,11 +11,16 @@ import ManifestRevisionPlugin from 'manifest-revision-webpack-plugin';
 import {
   PATHS,
   env,
+  sharedEnvs,
   currentScript,
   scriptOptions,
   namingConvention,
   buildNamingConvention,
 } from '../../_userSettings';
+
+const extractedSharedEnvs = Object.keys(process.env)
+  .filter(key => sharedEnvs.indexOf(key) !== -1)
+  .reduce((obj, key) => ({ [key]: process.env[key], ...obj }), {});
 
 const sharedPlugins = [
   new ProgressBarPlugin({ width: 40 }),
@@ -28,9 +33,9 @@ const sharedPlugins = [
       ? 'production'
       : process.env.NODE_ENV
     ),
-    // All other environment variables are passed through via `buildSettings`
+    // All other environment variables are passed through via `buildSettings` if defined in `sharedEnvs`
     buildSettings: {
-      env: JSON.stringify(process.env),
+      env: JSON.stringify(extractedSharedEnvs),
     },
   }),
 ];


### PR DESCRIPTION
Makes sure only explicitly defined environment variables are passed to the client.